### PR TITLE
UniRx の using エラーを除去する

### DIFF
--- a/Assets/Scripts/UnityModule/Command/VCS/Git.cs
+++ b/Assets/Scripts/UnityModule/Command/VCS/Git.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using UniRx;
 using UnityModule.Settings;
 
 namespace UnityModule.Command.VCS


### PR DESCRIPTION
## 💀 エラー

```
Assets/Modules/umm@git/Scripts/UnityModule/Command/VCS/Git.cs(7,33): error CS0246: The type or namespace name `IObservable' could not be found. Are you missing `System' using directive?
```

UniRx の using が残っているため、エラーが出てしまう。